### PR TITLE
license header fix for rat detection + exclusion of archetype content

### DIFF
--- a/netbeans-jakartaee-war-archetype/README.md
+++ b/netbeans-jakartaee-war-archetype/README.md
@@ -1,3 +1,24 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
 # Parameters
 
 The archetype can be configured via several system properties:

--- a/netbeans-jakartaee-war-archetype/pom.xml
+++ b/netbeans-jakartaee-war-archetype/pom.xml
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-  https://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
@@ -30,6 +30,18 @@ under the License.
     <packaging>maven-archetype</packaging>
 
     <name>Apache NetBeans Maven Archetypes: Jakarte EE Web Application Archetype</name>
-
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <!-- archetype result should be license agnostic -->
+                        <exclude>src/main/resources/archetype-resources/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/netbeans-jakartaee-war-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/netbeans-jakartaee-war-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 projectDir = new File(new File(request.outputDirectory), request.artifactId)
 
 jakartaEEVariant = request.getProperties().get("jakartaEEVariant")

--- a/netbeans-jakartaee-war-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/netbeans-jakartaee-war-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -8,7 +8,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-  https://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-  https://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an


### PR DESCRIPTION
fix for rat compatibility.
exclusion of all the resources for archetype so the result is without license.

will later change the ci-build on jenkins to execute apache-rat:check.

